### PR TITLE
slapd: add missing , to syncrepl config in bakery

### DIFF
--- a/slapd/lib/check_mk/base/cee/plugins/bakery/slapd.py
+++ b/slapd/lib/check_mk/base/cee/plugins/bakery/slapd.py
@@ -34,7 +34,7 @@ def get_slapd_files(conf: Dict[str, Any]) -> FileGenerator:
                 for syncreplconf in value:
                     content += ["      {"]
                     for key, value in syncreplconf.items():
-                        content += ["      '%s' => '%s'" % (key, value)]
+                        content += ["      '%s' => '%s'," % (key, value)]
                     content += ["      },"]
                 content += ["    ],"]
             else:


### PR DESCRIPTION
The syncrepl configuration via WATO leads to errors loading the configuration file, because there is a , missing.
This PR adds said ,

The mkp has to be rebuild.